### PR TITLE
HIR-446: Added a middleware to implement jwt token based authentication

### DIFF
--- a/example/settings.py
+++ b/example/settings.py
@@ -52,6 +52,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'squealy.middlewares.JWTAuthentication',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]

--- a/squealy/middlewares.py
+++ b/squealy/middlewares.py
@@ -46,7 +46,7 @@ class JWTAuthentication(object):
                 if group_object:
                     group_object.user_set.add(user)
             return user
-        except (    jwt.InvalidTokenError, KeyError):
+        except (jwt.InvalidTokenError, KeyError):
             return None
 
     def _extract_token(self, request):

--- a/squealy/middlewares.py
+++ b/squealy/middlewares.py
@@ -1,0 +1,62 @@
+import jwt
+from django.contrib.auth import login
+from django.contrib.auth.models import User, Group
+
+
+class JWTAuthentication(object):
+    """
+    Middleware class to authenticate and log in a user with details present in the jwt token.
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+        # One-time configuration and initialization.
+
+    def __call__(self, request):
+        # Code to be executed for each request before
+        # the view (and later middleware) are called.
+        token = self._extract_token(request)
+        if not request.user.is_authenticated() and token:
+            user = self._authenticate(token)
+            if user:
+                login(request, user)
+                request.user = user
+        response = self.get_response(request)
+
+        # Code to be executed for each request/response after
+        # the view is called.
+
+        return response
+
+    def _authenticate(self, token):
+        """"
+        Decode the jwt token and return the user. Create new user if the user does not exist already.
+        Add the user to groups that are provoded in the jwt token.
+        """
+        try:
+            # TODO: extract the secret from the env.
+            token_params = jwt.decode(token, 'secret', algorithms=['HS256'])
+            user_name = token_params['username']
+            user = User.objects.filter(username=user_name).first()
+            if not user:
+                user = User(username=user_name)
+                user.save()
+            groups = token_params['groups']
+            for group_name in groups:
+                group_object = Group.objects.filter(name=group_name).first()
+                if group_object:
+                    group_object.user_set.add(user)
+            return user
+        except (    jwt.InvalidTokenError, KeyError):
+            return None
+
+    def _extract_token(self, request):
+        """
+        To extract the access token from the request.
+        Assumption - The token is passed in key - 'accessToken'
+        """
+        if request.method == 'GET':
+            return request.GET.get('accessToken')
+        elif request.method == 'POST':
+            return request.POST.get('accessToken')
+        return None
+


### PR DESCRIPTION
- The token should be provided in the 'accessToken' key in GET or POST paramaters.
- The token payload to be of the following format: 
```
 {
  "username": "someuser",
  "groups": ["group1", "group2"]
}
```
- If the user is not present, a new user will be created.
- If the user is not attached to any of the groups, it will be added.
- New groups will NOT be created. The administrator should ensure groups-creation from the admin panel.
