### PR TITLE
Fix for several databases

### DIFF
--- a/squealyproj/utils.py
+++ b/squealyproj/utils.py
@@ -13,13 +13,13 @@ def extract_dj_database_urls(databases_as_string, DATABASES):
         for db in databases_as_array:
             db_config = dj_database_url.parse(db, conn_max_age=500)
             database_type = db.split(":")[0].strip()
-            if (database_type == 'postgres'):
+            if database_type == 'postgres':
                 if 'OPTIONS' not in db_config:
                     db_config['OPTIONS'] = {'options': ''}
                 db_config['OPTIONS']['options'] = '-c default_transaction_read_only=on'
             display_name = db_config['NAME']
             if db_config.get('OPTIONS') and db_config['OPTIONS'].get('display_name'):
-                display_name =  db_config['OPTIONS'].get('display_name')
+                display_name = db_config['OPTIONS'].get('display_name')
                 del db_config['OPTIONS']['display_name']
             DATABASES[display_name] = db_config
-            del DATABASES['query_db']
+        del DATABASES['query_db']


### PR DESCRIPTION
Hi,

First, thanks for this cool project. Right now I'm going through the process of "dockerizing" this project for our project, so it can integrate seamlessly with our infrastructure. While getting used to the project I encountered a bug, only reproducible when using more that one database in the `QUERY_DB` environment variable. The exception was due to a missing key in line 25 of this file. I think the intention here was to delete the default query db; however, putting this instruction inside the `for` loop attempts to delete it several times (if more that one DB is specified) and the application does not start. This small change seems worth sharing, so feel free to merge if appropriate. The other small changes are just suggested styling issues. Thanks again for the project, hope my input is valuable.