### PR TITLE
Make parameters initializers more forgiven

### DIFF
--- a/squealy/parameters.py
+++ b/squealy/parameters.py
@@ -13,7 +13,7 @@ class Parameter():
 
 
 class String(Parameter):
-    def __init__(self, name, description=None, default_value=None, valid_values=None):
+    def __init__(self, name, description=None, default_value=None, valid_values=None, **kwargs):
         self.default_value = default_value
         self.valid_values = valid_values
         self.name = name
@@ -34,7 +34,7 @@ class String(Parameter):
 
 
 class Date(Parameter):
-    def __init__(self, name, description=None, default_value=None, format=None):
+    def __init__(self, name, description=None, default_value=None, format=None, **kwargs):
         self.default_value = default_value
         self.format = format
         self.name = name
@@ -74,7 +74,7 @@ class Date(Parameter):
 
 
 class Datetime(Parameter):
-    def __init__(self, name, description=None, default_value=None, format=None):
+    def __init__(self, name, description=None, default_value=None, format=None, **kwargs):
         self.datetime_macros = {"today": self.now, "now": self.now}
         self.default_value = default_value
         self.format = format
@@ -109,7 +109,7 @@ class Datetime(Parameter):
 
 
 class Number(Parameter):
-    def __init__(self, name, description=None, default_value=None, valid_values=None):
+    def __init__(self, name, description=None, default_value=None, valid_values=None, **kwargs):
         self.default_value = default_value
         self.valid_values = valid_values
         self.name = name


### PR DESCRIPTION
Currently queries with `string` and `number` parameters fail to run by default with the error:

```
__init__() got an unexpected keyword argument 'format'
```

As described in #228, this happens because there is a `kwargs` called `format` that is always passed in the `POST` request to save a parameter even thought it's only used to by the `Date` and `Datetime` types.

This PR makes the initializers for the parameters more forgiven, meaning it won't throw errors if unknown parameters are passed to the class, they will just be silently consumed.